### PR TITLE
UK national carbon intensity data pipeline

### DIFF
--- a/uk_carbon_intensity.py
+++ b/uk_carbon_intensity.py
@@ -63,5 +63,19 @@ ds: xr.Dataset = xr.Dataset(
 )
 assert dict(ds.coords.dtypes) == {"time": np.dtype("<M8[ns]")}
 
+# Add more metadata to the xarray.Dataset
+# See https://carbon-intensity.github.io/api-definitions/#intensity-1
+ds["forecast"].attrs = dict(
+    description="The forecast Carbon Intensity for the half hour in units gCO2/kWh."
+)
+ds["actual"].attrs = dict(
+    description="The estimated actual Carbon Intensity for the half hour in units gCO2/kWh."
+)
+ds["intensity_index"].attrs = dict(
+    description="The index is a measure of the Carbon Intensity represented on a scale "
+    "between 'very low', 'low', 'moderate', 'high', 'very high'."
+)
+
+
 # Save to Zarr format
 ds.to_zarr(store="uk_national_carbon_intensity.zarr", consolidated=True)

--- a/uk_carbon_intensity.py
+++ b/uk_carbon_intensity.py
@@ -1,0 +1,67 @@
+"""
+Getting carbon intensity for the United Kingdom and storing in Zarr format.
+
+References:
+- https://carbonintensity.org.uk
+- https://carbon-intensity.github.io/api-definitions
+"""
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+
+# %%
+# Temporal date range
+start_date: str = "2022-09-01T00:00:00.000Z"
+end_date: str = "2022-09-30T00:00:00.000Z"
+
+
+# %%
+# Retrieve UK National carbon density data in JSON format from API.
+# Example JSON:
+# {
+#     "data": [
+#         {
+#             "from": "2018-01-20T12:00Z",
+#             "to": "2018-01-20T12:30Z",
+#             "intensity": {"forecast": 266, "actual": 263, "index": "moderate"},
+#         }
+#     ]
+# }
+df: pd.DataFrame = pd.read_json(
+    path_or_buf=f"https://api.carbonintensity.org.uk/intensity/{start_date}/{end_date}",
+    orient="split",
+    convert_dates=["from", "to"],
+)
+assert list(df.columns) == ["from", "to", "intensity"]
+assert list(df.dtypes) == [
+    pd.DatetimeTZDtype(unit="ns", tz="UTC"),
+    pd.DatetimeTZDtype(unit="ns", tz="UTC"),
+    np.object_,
+]
+
+# Split intensity column (dictionary format) into forecast, actual and index values
+df_intensity: pd.DataFrame = pd.json_normalize(data=df.intensity)
+assert list(df_intensity.columns) == ["forecast", "actual", "index"]
+assert list(df_intensity.dtypes) == [np.int64, np.int64, np.object_]
+
+# Create dataset by joining from/to dates with forecast/actual/index carbon intensity
+time_coords: pd.Series = df["from"]  # use start date as index coordinate
+ds: xr.Dataset = xr.Dataset(
+    data_vars={
+        "start_date": ("time", df["from"]),
+        "end_date": ("time", df["to"]),
+        "forecast": ("time", df_intensity["forecast"]),
+        "actual": ("time", df_intensity["actual"]),
+        "intensity_index": ("time", df_intensity["index"].astype(str)),
+    },
+    coords={"time": time_coords},
+    attrs={
+        "description": "UK National forecasted and actual carbon intensity data at half-hourly intervals"
+    },
+)
+assert dict(ds.coords.dtypes) == {"time": np.dtype("<M8[ns]")}
+
+# Save to Zarr format
+ds.to_zarr(store="uk_national_carbon_intensity.zarr", consolidated=True)


### PR DESCRIPTION
# Pull Request

## Description

Getting carbon intensity for the United Kingdom from 2020 to 2022 and storing in Zarr format.

References:
- https://carbonintensity.org.uk
- https://carbon-intensity.github.io/api-definitions

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [ ] Yes

Tested locally by running

```bash
cd hf-data-scripts/
python uk_carbon_intensity.py
```

Should produce a `uk_national_carbon_intensity.zarr` as output (~228KB).

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Yes

```python
import matplotlib.pyplot as plt
import xarray as xr

ds = xr.open_zarr(store="uk_national_carbon_intensity.zarr")

fig, ax = plt.subplots(figsize=(12, 5))
ds.actual.plot(ax=ax)
fig.savefig(fname="uk_carbon_intensity_2020-2022.png", dpi=300)
```
produces
![uk_carbon_intensity_2020-2022](https://user-images.githubusercontent.com/23487320/198901006-be3603da-b014-4c28-82ed-26f49072e3af.png)

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
